### PR TITLE
copied the variables from godotengine main css

### DIFF
--- a/bower_components/bootswatch/godot_lightly/variables.less
+++ b/bower_components/bootswatch/godot_lightly/variables.less
@@ -31,6 +31,7 @@
 
 @godot_coral:            #f57389;
 
+// variables from godotengine.org
 @transparent-cover: rgb(51, 63, 103, 0.4);
 @transparent-cover-darker: rgba(51, 63, 103, 0.9);
 

--- a/bower_components/bootswatch/godot_lightly/variables.less
+++ b/bower_components/bootswatch/godot_lightly/variables.less
@@ -31,6 +31,29 @@
 
 @godot_coral:            #f57389;
 
+@transparent-cover: rgb(51, 63, 103, 0.4);
+@transparent-cover-darker: rgba(51, 63, 103, 0.9);
+
+@base-color: #eff1f5;
+@base-color-text: #4a5365;
+@base-color-text-hl: #454b59;
+@base-color-text-title: #546b99;
+@base-color-text-subtitle: #8a9cc2;
+
+@dark-color: #333f67;
+@dark-color-text: lightsteelblue;
+@dark-color-text-hl: #d4e3f6;
+@dark-color-text-title: white;
+
+@primary-color: #3d8fcc;
+@primary-color-text: #d4edff;
+@primary-color-text-hl: white;
+@primary-color-text-title: white;
+
+@base-shadow: 0 0 4px rgba(0, 0, 0, .2);
+@more-shadow: 0 2px 10px rgba(0, 0, 0, .2);
+
+@accent-color: #f57389;
 
 //== Scaffolding
 //


### PR DESCRIPTION
We should try to migrate towards using the same variables and their names as the engine website to be consistent. Also has the benefit of making it easier to use the main website as an actual reference to inspect.