### PR TITLE
Increase Yaga reactions with the "hover" event

### DIFF
--- a/bower_components/bootswatch/godot_darkly/bootswatch.less
+++ b/bower_components/bootswatch/godot_darkly/bootswatch.less
@@ -1006,6 +1006,39 @@ li.L5, li.L6, li.L7, li.L8
   list-style-type: decimal !important;
 }
 
+// Change the size of YAGA reactions.
+span.UserReactionWrap
+{
+    & a img.ProfilePhoto
+    {
+        width: 32px;
+        height: 32px;
+        transition: width .2s ease-in-out, height .2s ease-in-out;
+    }
+    & span.ReactSprite
+    {
+        transform: scale(1);
+        transition: transform .2s ease-in-out, right .2s ease-in-out, bottom .2s ease-in-out;
+        right: -2px;
+        bottom: -2px;
+    }
+    
+    &:hover
+    {
+        & a img.ProfilePhoto
+        {
+            width: 48px;
+            height: 48px;
+        }
+        & span.ReactSprite
+        {
+            transform: scale(2);
+            right: -4px;
+            bottom: 0px;
+        }
+    }
+}
+
 // GodotEngine.org-like header stuff (practically copied from GodotEngine.org)
 // Note: This is kinda hacky, but it makes a similar looking result, so
 // I cannot complain too much. Probably needs to be redone in the future!

--- a/bower_components/bootswatch/godot_lightly/bootswatch.less
+++ b/bower_components/bootswatch/godot_lightly/bootswatch.less
@@ -1063,6 +1063,39 @@ li.L5, li.L6, li.L7, li.L8 {
   list-style-type: decimal !important;
 }
 
+// Change the size of YAGA reactions.
+span.UserReactionWrap
+{
+    & a img.ProfilePhoto
+    {
+        width: 32px;
+        height: 32px;
+        transition: width .2s ease-in-out, height .2s ease-in-out;
+    }
+    & span.ReactSprite
+    {
+        transform: scale(1);
+        transition: transform .2s ease-in-out, right .2s ease-in-out, bottom .2s ease-in-out;
+        right: -2px;
+        bottom: -2px;
+    }
+    
+    &:hover
+    {
+        & a img.ProfilePhoto
+        {
+            width: 48px;
+            height: 48px;
+        }
+        & span.ReactSprite
+        {
+            transform: scale(2);
+            right: -4px;
+            bottom: 0px;
+        }
+    }
+}
+
 
 // GodotEngine.org-like header stuff (practically copied from GodotEngine.org)
 // Note: This is kinda hacky, but it makes a similar looking result, so

--- a/bower_components/bootswatch/godot_lightly/variables.less
+++ b/bower_components/bootswatch/godot_lightly/variables.less
@@ -845,7 +845,7 @@
 //##
 
 @code-color:                  black;
-@code-bg:                     @#ebebeb;
+@code-bg:                     #ebebeb;
 
 @kbd-color:                   #fff;
 @kbd-bg:                      #333;


### PR DESCRIPTION
I made some changes to the CSS so Yaga reactions grow larger when they detect a "hover" event:

![Godot_Forums_YAGA_Reactions_Size_Increase_PR](https://user-images.githubusercontent.com/25082678/65804274-48b50680-e14f-11e9-81e4-ef81be9c86d7.gif)

*(I didn't download the latest profile pictures, so that's why one of them is missing)*

I also increased the default size of reactions slightly, from `21` pixels to `32` so they are a little easier to see. I think it makes the reactions easier to view and work with, while also not taking up too much space. That said, I'm not totally sure on the sizes, and I couldn't find a way to increase the size of the Yaga reaction icons without using `transform`, so the icon gets a bit blurry when the size increases.

If merged, this PR will close #31 
___________

I accidentally left a `@` in the variables for Godot Lightly on the last PR, so this PR also removes that so the theme compiles successfully.